### PR TITLE
feat: move date generation outside model

### DIFF
--- a/src/main/java/logion/backend/api/TokenRequestController.java
+++ b/src/main/java/logion/backend/api/TokenRequestController.java
@@ -1,5 +1,6 @@
 package logion.backend.api;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import logion.backend.annotation.RestQuery;
@@ -52,7 +53,7 @@ public class TokenRequestController {
                         tokenDescription.getBars()
                 );
         var id = UUID.randomUUID();
-        var request = tokenizationRequestFactory.newPendingTokenizationRequest(id, tokenDescription);
+        var request = tokenizationRequestFactory.newPendingTokenizationRequest(id, tokenDescription, LocalDateTime.now());
         request = tokenizationRequestCommands.addTokenizationRequest(request);
         return toView(request);
     }
@@ -88,7 +89,7 @@ public class TokenRequestController {
                         requestId,
                         rejectTokenRequestView.getRejectReason()
                 );
-        tokenizationRequestCommands.rejectTokenizationRequest(UUID.fromString(requestId), rejectTokenRequestView.getRejectReason());
+        tokenizationRequestCommands.rejectTokenizationRequest(UUID.fromString(requestId), rejectTokenRequestView.getRejectReason(), LocalDateTime.now());
     }
 
     @Autowired

--- a/src/main/java/logion/backend/commands/TokenizationRequestCommands.java
+++ b/src/main/java/logion/backend/commands/TokenizationRequestCommands.java
@@ -1,5 +1,6 @@
 package logion.backend.commands;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import javax.transaction.Transactional;
 import logion.backend.annotation.Commands;
@@ -23,10 +24,10 @@ public class TokenizationRequestCommands {
     @Autowired
     private TokenizationRequestRepository tokenizationRequestRepository;
 
-    public void rejectTokenizationRequest(UUID requestId, String rejectReason) {
+    public void rejectTokenizationRequest(UUID requestId, String rejectReason, LocalDateTime rejectedOn) {
         var request = tokenizationRequestRepository.findById(requestId)
                 .orElseThrow(() -> new IllegalArgumentException("Request does not exist"));
-        request.reject(rejectReason);
+        request.reject(rejectReason, rejectedOn);
         tokenizationRequestRepository.save(request);
     }
 }

--- a/src/main/java/logion/backend/model/tokenizationrequest/TokenizationRequestAggregateRoot.java
+++ b/src/main/java/logion/backend/model/tokenizationrequest/TokenizationRequestAggregateRoot.java
@@ -16,14 +16,14 @@ import lombok.Getter;
 @Entity(name = "tokenization_request")
 public class TokenizationRequestAggregateRoot {
 
-    public void reject(String reason) {
+    public void reject(String reason, LocalDateTime rejectedOn) {
         if(status != TokenizationRequestStatus.PENDING) {
             throw new IllegalStateException("Cannot reject non-pending request");
         }
 
         status = TokenizationRequestStatus.REJECTED;
         rejectReason = reason;
-        decisionOn = LocalDateTime.now();
+        decisionOn = rejectedOn;
     }
 
     public TokenizationRequestDescription getDescription() {

--- a/src/main/java/logion/backend/model/tokenizationrequest/TokenizationRequestFactory.java
+++ b/src/main/java/logion/backend/model/tokenizationrequest/TokenizationRequestFactory.java
@@ -7,7 +7,7 @@ import logion.backend.annotation.Factory;
 @Factory
 public class TokenizationRequestFactory {
 
-    public TokenizationRequestAggregateRoot newPendingTokenizationRequest(UUID id, TokenizationRequestDescription tokenDescription) {
+    public TokenizationRequestAggregateRoot newPendingTokenizationRequest(UUID id, TokenizationRequestDescription tokenDescription, LocalDateTime createdOn) {
         var request = new TokenizationRequestAggregateRoot();
         request.id = id;
         request.status = TokenizationRequestStatus.PENDING;
@@ -15,7 +15,7 @@ public class TokenizationRequestFactory {
         request.legalOfficerAddress = tokenDescription.getLegalOfficerAddress();
         request.requestedTokenName = tokenDescription.getRequestedTokenName();
         request.bars = tokenDescription.getBars();
-        request.createdOn = LocalDateTime.now();
+        request.createdOn = createdOn;
         return request;
     }
 }

--- a/src/test/java/logion/backend/commands/TokenizationRequestCommandsTest.java
+++ b/src/test/java/logion/backend/commands/TokenizationRequestCommandsTest.java
@@ -1,5 +1,6 @@
 package logion.backend.commands;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 import logion.backend.model.tokenizationrequest.TokenizationRequestAggregateRoot;
@@ -19,6 +20,7 @@ import static org.mockito.Mockito.when;
 class TokenizationRequestCommandsTest {
 
     private static final String REJECT_REASON = "Illegal";
+    private static final LocalDateTime REJECTED_ON = LocalDateTime.now();
 
     @Test
     void addTokenizationRequest() {
@@ -75,11 +77,11 @@ class TokenizationRequestCommandsTest {
     }
 
     private void whenRejectTokenizationRequest() {
-        commands.rejectTokenizationRequest(request.getId(), REJECT_REASON);
+        commands.rejectTokenizationRequest(request.getId(), REJECT_REASON, REJECTED_ON);
     }
 
     private void thenRequestRejected() {
-        verify(request).reject(REJECT_REASON);
+        verify(request).reject(REJECT_REASON, REJECTED_ON);
     }
 
     @Test

--- a/src/test/java/logion/backend/model/tokenizationrequest/TokenizationRequestAggregateRootTest.java
+++ b/src/test/java/logion/backend/model/tokenizationrequest/TokenizationRequestAggregateRootTest.java
@@ -2,6 +2,8 @@ package logion.backend.model.tokenizationrequest;
 
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -9,13 +11,15 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class TokenizationRequestAggregateRootTest {
 
     private static final String REJECT_REASON = "Illegal";
+    private static final LocalDateTime REJECTED_ON = LocalDateTime.now();
 
     @Test
     void rejectPending() {
         givenRequestWithStatus(TokenizationRequestStatus.PENDING);
-        whenRejecting(REJECT_REASON);
+        whenRejecting(REJECT_REASON, REJECTED_ON);
         thenRequestStatusIs(TokenizationRequestStatus.REJECTED);
         thenRequestRejectReasonIs(REJECT_REASON);
+        thenDecisionOnIs(REJECTED_ON);
     }
 
     private void givenRequestWithStatus(TokenizationRequestStatus status) {
@@ -25,8 +29,8 @@ class TokenizationRequestAggregateRootTest {
 
     private TokenizationRequestAggregateRoot request;
 
-    private void whenRejecting(String rejectReason) {
-        request.reject(rejectReason);
+    private void whenRejecting(String rejectReason, LocalDateTime rejectedOn) {
+        request.reject(rejectReason, rejectedOn);
     }
 
     private void thenRequestStatusIs(TokenizationRequestStatus expectedStatus) {
@@ -37,9 +41,13 @@ class TokenizationRequestAggregateRootTest {
         assertThat(request.getRejectReason(), equalTo(rejectReason));
     }
 
+    private void thenDecisionOnIs(LocalDateTime rejectedOn) {
+        assertThat(request.getDecisionOn(), equalTo(rejectedOn));
+    }
+
     @Test
     void rejectRejectedThrows() {
         givenRequestWithStatus(TokenizationRequestStatus.REJECTED);
-        assertThrows(IllegalStateException.class, () -> whenRejecting(REJECT_REASON));
+        assertThrows(IllegalStateException.class, () -> whenRejecting(REJECT_REASON, REJECTED_ON));
     }
 }

--- a/src/test/java/logion/backend/model/tokenizationrequest/TokenizationRequestFactoryTest.java
+++ b/src/test/java/logion/backend/model/tokenizationrequest/TokenizationRequestFactoryTest.java
@@ -1,5 +1,6 @@
 package logion.backend.model.tokenizationrequest;
 
+import java.time.LocalDateTime;
 import java.util.UUID;
 import logion.backend.model.Ss58Address;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ class TokenizationRequestFactoryTest {
                 .bars(1)
                 .build();
         givenTokenDescription(description);
+        givenCreatedOn(LocalDateTime.now());
         whenCreatingTokenizationRequest();
         thenPendingRequestCreatedWithDescription(description);
     }
@@ -34,16 +36,23 @@ class TokenizationRequestFactoryTest {
 
     private TokenizationRequestDescription tokenDescription;
 
-    private void whenCreatingTokenizationRequest() {
-        createdTokenizationRequest = factory.newPendingTokenizationRequest(requestId, tokenDescription);
+    private void givenCreatedOn(LocalDateTime createdOn) {
+        this.createdOn = createdOn;
     }
 
-    private TokenizationRequestFactory factory = new TokenizationRequestFactory();
+    private LocalDateTime createdOn;
+
+    private void whenCreatingTokenizationRequest() {
+        createdTokenizationRequest = factory.newPendingTokenizationRequest(requestId, tokenDescription, createdOn);
+    }
+
+    private final TokenizationRequestFactory factory = new TokenizationRequestFactory();
 
     private TokenizationRequestAggregateRoot createdTokenizationRequest;
 
     private void thenPendingRequestCreatedWithDescription(TokenizationRequestDescription description) {
         assertThat(createdTokenizationRequest.getId(), equalTo(requestId));
         assertThat(createdTokenizationRequest.getDescription(), equalTo(description));
+        assertThat(createdTokenizationRequest.getCreatedOn(), equalTo(createdOn));
     }
 }

--- a/src/test/java/logion/backend/web/TokenRequestWebTest.java
+++ b/src/test/java/logion/backend/web/TokenRequestWebTest.java
@@ -1,5 +1,6 @@
 package logion.backend.web;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -64,7 +65,7 @@ class TokenRequestWebTest {
         var tokenizationRequest = mock(TokenizationRequestAggregateRoot.class);
         when(tokenizationRequest.getDescription()).thenReturn(expectedTokenDescription);
 
-        when(tokenizationRequestFactory.newPendingTokenizationRequest(any(), eq(expectedTokenDescription)))
+        when(tokenizationRequestFactory.newPendingTokenizationRequest(any(), eq(expectedTokenDescription), any()))
             .thenReturn(tokenizationRequest);
         when(tokenizationRequestCommands.addTokenizationRequest(tokenizationRequest)).thenReturn(tokenizationRequest);
 
@@ -136,7 +137,7 @@ class TokenRequestWebTest {
                 .andExpect(matcher);
 
         if(signatureVerifyResult) {
-            verify(tokenizationRequestCommands).rejectTokenizationRequest(requestId, REJECT_REASON);
+            verify(tokenizationRequestCommands).rejectTokenizationRequest(eq(requestId), eq(REJECT_REASON), isA(LocalDateTime.class));
         }
     }
 


### PR DESCRIPTION
Small PR to address these 2 comments from @gdethier in [this PR](https://github.com/logion-network/logion-backend/pull/10)
> [Generally, I leave dates generation outside of the model in order to enable better control when testing.](https://github.com/logion-network/logion-backend/pull/10#discussion_r637024295)
and 
> [Generally, I leave dates generation outside of the model in order to enable better control when testing.](https://github.com/logion-network/logion-backend/pull/10#discussion_r637024752)